### PR TITLE
respect config.paths object is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,16 @@ module.exports = function(config, options){
                 return {path: path.join(config.baseUrl, path.relative(config.baseUrl, context.toUrl(name))) + '.js', name: name};
               }
             });
+
+            if(typeof config.paths === 'object'){
+              for(var key in config.paths){
+                if(config.paths[key] === filename){
+                  filename = key;
+                  break;
+                }
+              }
+            }
+
             var name = nameAnonymousModule(module.defineCall, filename);
           }else{
             var dependencies = [];


### PR DESCRIPTION
Thanks for this great npm/gulp port of r.js

As far as I can see, if a paths object is passed as a property of the requireJS config object, it is not used.

This code checks for the existence of a paths property, and rewrites filenames as necessary.